### PR TITLE
Local MongoDB ++ concurrent queries results

### DIFF
--- a/findings/faiss_mongodb_rag.py
+++ b/findings/faiss_mongodb_rag.py
@@ -1,0 +1,156 @@
+import git
+import os
+from pathlib import Path
+import pymongo
+from sentence_transformers import SentenceTransformer
+import numpy as np
+import faiss
+import time
+
+# MongoDB connection
+REPO_DIR = "byzfl_repo"
+client = pymongo.MongoClient("mongodb+srv://helenlkhoury:PpMIpywcSCsxqb2n@rag.kpcg2.mongodb.net/?retryWrites=true&w=majority&appName=RAG")
+db = client.byzfl_db  
+collection = db.code_chunks  
+
+# Load Sentence Transformer Model
+model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')  # 384-dimensional vectors
+dimension = 384  # Embedding dimension for FAISS index
+
+# 1️⃣ Clone Repository
+def clone_repository(repo_url: str, target_dir: str) -> None:
+    if not os.path.exists(target_dir):
+        print(f"Cloning repository from {repo_url} to {target_dir}...")
+        git.Repo.clone_from(repo_url, target_dir)
+    else:
+        print(f"Repository already cloned at {target_dir}")
+
+# 2️⃣ Extract Code Files
+def extract_code_files(repo_dir: str) -> list[dict]:
+    code_files = []
+    valid_extensions = {".py", ".cpp", ".h", ".hpp"}
+    for root, _, files in os.walk(repo_dir):
+        for file in files:
+            if Path(file).suffix in valid_extensions:
+                file_path = os.path.join(root, file)
+                try:
+                    with open(file_path, "r", encoding="utf-8") as f:
+                        content = f.read()
+                    code_files.append({
+                        "path": file_path,
+                        "content": content,
+                        "filename": file
+                    })
+                except Exception as e:
+                    print(f"Error reading {file_path}: {e}")
+    return code_files
+
+# 3️⃣ Chunking Code Content
+def chunk_content(content: str, max_length: int = 512) -> list[str]:
+    return [content[i:i + max_length] for i in range(0, len(content), max_length)]
+
+# 4️⃣ Generating Embeddings and Building FAISS Index
+def generate_embeddings_and_index(code_files: list[dict]) -> tuple[list[dict], faiss.IndexFlatL2]:
+    documents = []
+    embeddings = []
+    for file in code_files:
+        chunks = chunk_content(file["content"])
+        file_size = len(file["content"])
+        for i, chunk in enumerate(chunks):
+            embedding = model.encode(chunk)
+            embeddings.append(embedding)
+            documents.append({
+                "path": file["path"],
+                "filename": file["filename"],
+                "size": file_size,
+                "chunk_id": i,
+                "content": chunk,
+                "embedding": embedding.tolist()  # Store as list in MongoDB
+            })
+
+    # Build FAISS index
+    embeddings_np = np.array(embeddings, dtype=np.float32)
+    index = faiss.IndexFlatL2(dimension)  # L2 distance index
+    index.add(embeddings_np)  # Add embeddings to FAISS index
+
+    return documents, index
+
+# 5️⃣ Storing Documents in MongoDB
+def store_documents(documents: list[dict]) -> None:
+    collection.delete_many({})  # Clear existing data (optional, for fresh start)
+    collection.insert_many(documents)
+    print(f"Stored {len(documents)} documents in MongoDB.")
+
+# 6️⃣ FAISS Vector Search
+def faiss_search(query: str, index: faiss.IndexFlatL2, k: int = 5) -> list[dict]:
+    query_embedding = model.encode(query).reshape(1, -1).astype(np.float32)
+    distances, indices = index.search(query_embedding, k)  # FAISS search
+
+    # Fetch corresponding documents from MongoDB
+    results = []
+    for idx, distance in zip(indices[0], distances[0]):
+        doc = collection.find_one({"chunk_id": int(idx % 1000), "size": {"$exists": True}})  # Adjust logic based on unique identifier
+        if doc:
+            results.append({**doc, "score": 1 - distance / 2})  # Normalize score (optional)
+
+    return results
+
+# 7️⃣ Measure MongoDB and FAISS Performance
+def check_performance(index: faiss.IndexFlatL2):
+    admin_db = client["admin"]
+
+    # Check MongoDB current operations
+    try:
+        print("\n🔍 Checking current operations in MongoDB (db.currentOp()):")
+        current_operations = admin_db.command("currentOp")
+        print(current_operations)
+    except pymongo.errors.OperationFailure as e:
+        print(f"⚠️ Permission Error: {e}")
+
+    # FAISS index stats
+    print("\n🛠️ FAISS Index Stats:")
+    print(f"Total vectors in FAISS index: {index.ntotal}")
+
+# 8️⃣ Running a RAG Query with FAISS
+def rag_query(query: str, index: faiss.IndexFlatL2) -> str:
+    results = faiss_search(query, index)
+    if not results:
+        return "No relevant code found."
+    context = "\n\n".join([f"{r['filename']}:\n{r['content']}" for r in results])
+    return f"Based on the code in the byzfl repository:\n{context}"
+
+# 9️⃣ Benchmark Queries with FAISS
+def benchmark_queries(queries: list[str], index: faiss.IndexFlatL2) -> dict:
+    results = {}
+    for query in queries:
+        start_time = time.time()
+        response = rag_query(query, index)
+        latency = time.time() - start_time
+        results[query] = {"latency": latency, "response": response}
+
+        print(f"Query: {query}")
+        print(f"Latency: {latency:.2f} seconds")
+        print(f"Response: {response[:200]}...\n")
+
+    return results
+
+# 🔟 Main Execution
+if __name__ == "__main__":
+    # Clone and process repository
+    clone_repository("https://github.com/LPD-EPFL/byzfl.git", REPO_DIR)
+    code_files = extract_code_files(REPO_DIR)
+    documents, faiss_index = generate_embeddings_and_index(code_files)
+    store_documents(documents)
+
+    # Check performance
+    check_performance(faiss_index)
+
+    # Run benchmark tests
+    test_queries = [
+        "How does the byzfl code handle Byzantine faults?",
+        "What is the role of the consensus algorithm in byzfl?",
+        "Show me the message passing logic in byzfl."
+    ]
+    benchmark_results = benchmark_queries(test_queries, faiss_index)
+    avg_latency = np.mean([r["latency"] for r in benchmark_results.values()])
+    print(f"⚡ Average Latency with FAISS: {avg_latency:.2f} seconds")

--- a/findings/mongodb_benchmark.py
+++ b/findings/mongodb_benchmark.py
@@ -6,16 +6,18 @@ from pymongo import ReplaceOne
 from sentence_transformers import SentenceTransformer
 import numpy as np
 import time
+import json
 
+# MongoDB Atlas connection
 REPO_DIR = "byzfl_repo"
-
 client = pymongo.MongoClient("mongodb+srv://helenlkhoury:PpMIpywcSCsxqb2n@rag.kpcg2.mongodb.net/?retryWrites=true&w=majority&appName=RAG")
 db = client.byzfl_db  
 collection = db.code_chunks 
 
-model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2') # embedding model (384-dimensional vectors)
+# Load Sentence Transformer Model
+model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')  # 384-dimensional vectors
 
-
+# 1️⃣ Clone Repository
 def clone_repository(repo_url: str, target_dir: str) -> None:
     """Clone the GitHub repository to a local directory."""
     if not os.path.exists(target_dir):
@@ -24,6 +26,7 @@ def clone_repository(repo_url: str, target_dir: str) -> None:
     else:
         print(f"Repository already cloned at {target_dir}")
 
+# 2️⃣ Extract Code Files
 def extract_code_files(repo_dir: str) -> list[dict]:
     """Extract content from code files in the repository."""
     code_files = []
@@ -44,119 +47,91 @@ def extract_code_files(repo_dir: str) -> list[dict]:
                     print(f"Error reading {file_path}: {e}")
     return code_files
 
+# 3️⃣ Chunking Code Content
 def chunk_content(content: str, max_length: int = 512) -> list[str]:
     """Split content into chunks of max_length characters."""
     return [content[i:i + max_length] for i in range(0, len(content), max_length)]
 
+# 4️⃣ Generate Embeddings
 def generate_embeddings(code_files: list[dict]) -> list[dict]:
     """Generate embeddings for each code file, splitting into chunks if needed."""
     documents = []
     for file in code_files:
         chunks = chunk_content(file["content"])
-        file_size = len(file["content"])  # Measure file size in characters
+        file_size = len(file["content"])
         for i, chunk in enumerate(chunks):
-            embedding = model.encode(chunk).tolist()  # Convert NumPy array to list
+            embedding = model.encode(chunk).tolist()
             documents.append({
                 "path": file["path"],
                 "filename": file["filename"],
-                "size": file_size,  # Include size
+                "size": file_size,
                 "chunk_id": i,
                 "content": chunk,
-                "embedding": embedding  # Ensure this matches the MongoDB vector index
+                "embedding": embedding
             })
     return documents
 
+# 5️⃣ Store Documents and Measure Data Size
 def store_documents(documents: list[dict]) -> None:
     """Store documents with embeddings and metadata in MongoDB."""
+    start_time = time.time()
     requests = [
         ReplaceOne(
             {"path": doc["path"], "chunk_id": doc["chunk_id"]},  # Unique identifier
-            doc,  
+            doc,
             upsert=True
-        ) 
+        )
         for doc in documents
     ]
     if requests:
         result = collection.bulk_write(requests)
         print(f"Stored {result.upserted_count} new documents, modified {result.modified_count} existing documents.")
+    
+    latency = time.time() - start_time
+    data_size = len(json.dumps(documents)) / 1024 / 1024  # MB
+    print(f"Write Latency: {latency:.2f} seconds")
+    print(f"Data Size: {data_size:.2f} MB")
 
-def vector_search(query: str, k: int = 5) -> list[dict]:
-    """Perform a vector search on the collection using the correct Atlas Vector Search syntax."""
-    query_embedding = model.encode(query).tolist()
-    print("Query embedding length:", len(query_embedding))  # Debug
-
-    pipeline = [
-        {
-            "$vectorSearch": {
-                "index": "vector_index",
-                "path": "embedding",
-                "queryVector": query_embedding,
-                "numCandidates": 100,
-                "limit": k
-            }
-        },
-        {
-            "$project": {
-                "filename": 1,
-                "size": 1,  # Include size in results
-                "content": 1,
-                "score": {"$meta": "vectorSearchScore"}
-            }
-        },
-        {
-            "$sort": {"size": -1}  # Sort by document size (descending)
-        }
-    ]
-
+# 6️⃣ Create Vector Index (Manual Step or Programmatic Attempt)
+def create_vector_index():
+    """Attempt to create the vector index programmatically (requires Atlas Search API access)."""
     try:
-        results = list(collection.aggregate(pipeline))
-        print("Raw search results:", results)  # Debug output
-        return results
-    except Exception as e:
-        print(f"Error executing vector search: {e}")
-        return []
-
-def rag_query(query: str) -> str:
-    """Perform a RAG query and return a response using retrieved code chunks."""
-    results = vector_search(query)
-    if not results:
-        return "No relevant code found."
-    context = "\n\n".join([f"{r['filename']}:\n{r['content']}" for r in results])
-    return f"Based on the code in the byzfl repository:\n{context}"
-
-def benchmark_queries(queries: list[str]) -> dict:
-    """Benchmark the RAG system with multiple queries."""
-    results = {}
-    for query in queries:
-        start_time = time.time()
-        response = rag_query(query)
-        latency = time.time() - start_time
-        results[query] = {
-            "latency": latency,
-            "response": response
+        # Note: MongoDB Atlas Search indexes are typically created via the UI or Atlas API, not PyMongo directly.
+        # This is a placeholder; you’ll need to create it manually or use the Atlas API.
+        index_definition = {
+            "fields": [
+                {
+                    "numDimensions": 384,
+                    "path": "embedding",
+                    "similarity": "cosine",
+                    "type": "vector"
+                }
+            ]
         }
-        print(f"Query: {query}")
-        print(f"Latency: {latency:.2f} seconds")
-        print(f"Response: {response[:200]}...\n")  # Truncate for brevity
-    return results
+        print("Vector index creation must be done manually in Atlas UI or via Atlas API.")
+        print("Index definition to use:")
+        print(json.dumps(index_definition, indent=2))
+    except Exception as e:
+        print(f"Error attempting to create index: {e}")
 
-# Main execution
+# Main Execution
 if __name__ == "__main__":
-    # Clone and process repository
+    # Step 1: Drop existing collection (optional, for fresh start)
+    collection.drop()
+    print("Dropped existing 'code_chunks' collection (if it existed).")
+
+    # Step 2: Create vector index (manual step required)
+    create_vector_index()
+    print("Please create the vector index named 'vector_index' in Atlas UI with the above definition.")
+    print("Waiting 30 seconds for manual index creation (adjust as needed)...")
+    time.sleep(30)  # Give time to manually create the index if needed
+
+    # Step 3: Clone, process, and populate
     clone_repository("https://github.com/LPD-EPFL/byzfl.git", REPO_DIR)
     code_files = extract_code_files(REPO_DIR)
     documents = generate_embeddings(code_files)
     store_documents(documents)
 
-    # Wait for index to be active (manual check required in Atlas UI)
-    print("Please ensure the 'vector_index' is active in Atlas Search before proceeding with queries.")
-
-    # Benchmark with test queries
-    test_queries = [
-        "How does the byzfl code handle Byzantine faults?",
-        "What is the role of the consensus algorithm in byzfl?",
-        "Show me the message passing logic in byzfl."
-    ]
-    benchmark_results = benchmark_queries(test_queries)
-    avg_latency = np.mean([r["latency"] for r in benchmark_results.values()])
-    print(f"Average Latency: {avg_latency:.2f} seconds")
+    # Verify collection population
+    doc_count = collection.count_documents({})
+    print(f"Collection 'code_chunks' now contains {doc_count} documents.")

--- a/findings/no_indexing_mongodb.py
+++ b/findings/no_indexing_mongodb.py
@@ -1,0 +1,154 @@
+import git
+import os
+from pathlib import Path
+import pymongo
+from sentence_transformers import SentenceTransformer
+import numpy as np
+import time
+
+# MongoDB connection
+REPO_DIR = "byzfl_repo"
+client = pymongo.MongoClient("mongodb+srv://helenlkhoury:PpMIpywcSCsxqb2n@rag.kpcg2.mongodb.net/?retryWrites=true&w=majority&appName=RAG")
+db = client.byzfl_db  
+collection = db.code_chunks  
+
+# Load Sentence Transformer Model
+model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2') # 384-dimensional vectors
+
+# 1️⃣ Clone Repository (Same as before)
+def clone_repository(repo_url: str, target_dir: str) -> None:
+    if not os.path.exists(target_dir):
+        print(f"Cloning repository from {repo_url} to {target_dir}...")
+        git.Repo.clone_from(repo_url, target_dir)
+    else:
+        print(f"Repository already cloned at {target_dir}")
+
+# 2️⃣ Extract Code Files
+def extract_code_files(repo_dir: str) -> list[dict]:
+    code_files = []
+    valid_extensions = {".py", ".cpp", ".h", ".hpp"}
+    for root, _, files in os.walk(repo_dir):
+        for file in files:
+            if Path(file).suffix in valid_extensions:
+                file_path = os.path.join(root, file)
+                try:
+                    with open(file_path, "r", encoding="utf-8") as f:
+                        content = f.read()
+                    code_files.append({
+                        "path": file_path,
+                        "content": content,
+                        "filename": file
+                    })
+                except Exception as e:
+                    print(f"Error reading {file_path}: {e}")
+    return code_files
+
+# 3️⃣ Chunking Code Content
+def chunk_content(content: str, max_length: int = 512) -> list[str]:
+    return [content[i:i + max_length] for i in range(0, len(content), max_length)]
+
+# 4️⃣ Generating Embeddings
+def generate_embeddings(code_files: list[dict]) -> list[dict]:
+    documents = []
+    for file in code_files:
+        chunks = chunk_content(file["content"])
+        file_size = len(file["content"])  # Measure file size in characters
+        for i, chunk in enumerate(chunks):
+            embedding = model.encode(chunk).tolist()  # Convert NumPy array to list
+            documents.append({
+                "path": file["path"],
+                "filename": file["filename"],
+                "size": file_size,
+                "chunk_id": i,
+                "content": chunk,
+                "embedding": embedding  # Store without an index
+            })
+    return documents
+
+# 5️⃣ Storing Documents Without Indexing
+def store_documents(documents: list[dict]) -> None:
+    collection.insert_many(documents)  # No indexing, raw insert
+    print(f"Stored {len(documents)} documents without an index.")
+
+# 6️⃣ Brute-Force Vector Search (Without Index)
+def brute_force_search(query: str, k: int = 5) -> list[dict]:
+    """Manually retrieve all documents and compute similarity in Python."""
+    query_embedding = model.encode(query)
+
+    # Retrieve all documents (VERY SLOW if dataset is large)
+    all_docs = list(collection.find({}, {"filename": 1, "size": 1, "content": 1, "embedding": 1}))
+
+    # Compute cosine similarity manually
+    results = []
+    for doc in all_docs:
+        doc_embedding = np.array(doc["embedding"])
+        similarity = np.dot(query_embedding, doc_embedding) / (np.linalg.norm(query_embedding) * np.linalg.norm(doc_embedding))
+        results.append({**doc, "score": similarity})
+
+    # Sort results by similarity (descending order)
+    results = sorted(results, key=lambda x: x["score"], reverse=True)[:k]
+
+    return results
+
+# 7️⃣ Measure MongoDB Performance Without Index
+def check_performance():
+    """Check MongoDB performance using db.currentOp() and explain()."""
+    
+    admin_db = client["admin"]  # Switch to admin database
+
+    # Check current operations (requires admin access)
+    try:
+        print("\n🔍 Checking current operations in MongoDB (db.currentOp()):")
+        current_operations = admin_db.command("currentOp")
+        print(current_operations)
+    except pymongo.errors.OperationFailure as e:
+        print(f"⚠️ Permission Error: {e}")
+
+    # Use explain() to analyze query execution
+    print("\n🛠️ Checking query performance with explain():")
+    sample_query = collection.find({"filename": "attacks.py"}).explain()
+    print(sample_query)
+
+# 8️⃣ Running a RAG Query
+def rag_query(query: str) -> str:
+    results = brute_force_search(query)
+    if not results:
+        return "No relevant code found."
+    context = "\n\n".join([f"{r['filename']}:\n{r['content']}" for r in results])
+    return f"Based on the code in the byzfl repository:\n{context}"
+
+# 9️⃣ Benchmark Queries Without Index
+def benchmark_queries(queries: list[str]) -> dict:
+    results = {}
+    for query in queries:
+        start_time = time.time()
+        response = rag_query(query)
+        latency = time.time() - start_time
+        results[query] = {"latency": latency, "response": response}
+
+        print(f"Query: {query}")
+        print(f"Latency: {latency:.2f} seconds")
+        print(f"Response: {response[:200]}...\n")  # Truncate output
+
+    return results
+
+# 🔟 Main Execution
+if __name__ == "__main__":
+    # Clone and process repository
+    clone_repository("https://github.com/LPD-EPFL/byzfl.git", REPO_DIR)
+    code_files = extract_code_files(REPO_DIR)
+    documents = generate_embeddings(code_files)
+    store_documents(documents)
+
+    # 🔍 Check MongoDB Performance
+    check_performance()
+
+    # Run benchmark tests
+    test_queries = [
+        "How does the byzfl code handle Byzantine faults?",
+        "What is the role of the consensus algorithm in byzfl?",
+        "Show me the message passing logic in byzfl."
+    ]
+    benchmark_results = benchmark_queries(test_queries)
+    avg_latency = np.mean([r["latency"] for r in benchmark_results.values()])
+    print(f"⚡ Average Latency Without Indexing: {avg_latency:.2f} seconds")


### PR DESCRIPTION
I ran a local MongoDB 8.0.5 setup on Ubuntu 22.04 to benchmark a RAG system processing the byzfl repository, which contained 248,063 bytes (0.24 MB) of raw code across 498 chunks after processing into 4.32 MB with embeddings. Initial indexing took 8.83 seconds, and storage completed in a swift 0.05 seconds with negligible disk I/O. Across three runs, single-threaded query latencies averaged 0.01 seconds for k=2, k=5, and k=10, with search latency consistently at 0.00 seconds and query overhead (embedding generation) at 0.01–0.03 seconds, showing remarkable consistency (std dev ≤ 0.01). Under 10-thread concurrency, average latency rose to 0.08–0.09 seconds (std dev 0.01), an 800% increase from single-threaded performance, driven by query overhead (0.06–0.11 seconds) as the bottleneck. 