### PR TITLE
Improve robustness for full dataset runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,58 @@ sudo apt-get install -y mongodb-atlas-cli
 ```
 
 ---
+---
+
+### Generating a HotpotQA provenance subset
+
+For quick tests you can build a mini KILT corpus that only contains the documents referenced in the HotpotQA dataset:
+
+```bash
+python generate_hotpotqa_subset.py --output hotpotqa_subset.jsonl
+```
+
+Use this file as the corpus when embedding documents to speed up evaluation on a small scale.
+
+To use the subset in the pipeline, set `CORPUS_NAME` in `config.py` to the path
+of the generated JSONL file:
+
+```python
+CORPUS_NAME = "hotpotqa_subset.jsonl"
+```
+
+The data loader will detect the `.jsonl` extension and load the corpus from this
+file. After updating the path run the `main.py` script to embed the subset and
+evaluate retrieval performance.
+
+### Running on PubMedQA
+
+To evaluate the pipeline on the PubMedQA questions, change the dataset configuration in `config.py`:
+
+```python
+DATASET_NAME = "facebook/kilt_tasks"
+SUBSET_NAME = "pubmedqa"
+```
+
+Then run `main.py` as usual.
+
+### Running Each Model on a Separate VM
+
+To avoid GPU/CPU exhaustion when using the full corpus you can evaluate one model per machine. Set the `MODELS` environment variable to the desired model before running `main.py`:
+
+```bash
+export MODELS="BAAI/bge-base-en-v1.5"
+python main.py
+```
+
+Only the models listed in `MODELS` will be executed. Without this variable all predefined models run sequentially.
+
+### Using the Full KILT Corpus
+
+When embedding the entire Wikipedia corpus set the limits in `config.py` to `None`:
+
+```python
+CORPUS_LIMIT = None
+limit = None
+```
+
+Reducing `EMBED_BATCH_SIZE` and `BATCH_SIZE` may prevent out-of-memory errors. During evaluation the script now writes each batch's results to `results_<model>.jsonl` (or the path from `OUTPUT_FILE`) so progress is saved even if a timeout occurs.

--- a/data_loader.py
+++ b/data_loader.py
@@ -69,8 +69,16 @@ def load_and_store_data(limit=None, embedding_generator=None, embedding_size=Non
         
     # Load KILT corpus (documents) using streaming to avoid large memory usage
     start_time = time.time()
-    logger.warning(f"Loading KILT corpus: {CORPUS_NAME} (streaming mode)")
-    kilt_corpus = load_dataset(CORPUS_NAME, split="train", streaming=True)
+    logger.warning(f"Loading KILT corpus: {CORPUS_NAME}")
+    if CORPUS_NAME.endswith(".jsonl") or CORPUS_NAME.endswith(".json"):
+        kilt_corpus = load_dataset(
+            "json",
+            data_files=CORPUS_NAME,
+            split="train",
+            streaming=True,
+        )
+    else:
+        kilt_corpus = load_dataset(CORPUS_NAME, split="train", streaming=True)
     if CORPUS_LIMIT:
         kilt_corpus = kilt_corpus.take(CORPUS_LIMIT)
     timings["dataset_load"] = time.time() - start_time

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,4 +1,5 @@
 import time
+import json
 from pymongo import MongoClient
 from config import DB_URI, DB_NAME, VERBOSE, BATCH_SIZE, COLLECTION_NAME, K
 from retrieval import retrieve_top_k
@@ -8,8 +9,16 @@ from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
-def process_query(entries, collection, embedding_generator, num_candidates):
-    """Process a batch of queries and return metrics with timing."""
+def process_query(entries, collection, embedding_generator, num_candidates, max_retries=3):
+    """Process a batch of queries and return metrics with timing.
+
+    Args:
+        entries: List of query dataset entries.
+        collection: MongoDB collection to search.
+        embedding_generator: Embedding model wrapper.
+        num_candidates: Number of candidates to retrieve.
+        max_retries: Number of times to retry a failed vector search.
+    """
     logger.info(f"Processing batch of {len(entries)} queries.")
     queries = [entry["input"] for entry in entries]
 
@@ -19,7 +28,9 @@ def process_query(entries, collection, embedding_generator, num_candidates):
         query_embeddings_list, embed_timings = embedding_generator.generate_embedding(queries)
 
         # Retrieve documents
-        results, search_timings = retrieve_top_k(query_embeddings_list, collection, num_candidates)
+        results, search_timings = retrieve_top_k(
+            query_embeddings_list, collection, num_candidates, retries=max_retries
+        )
     except Exception as e:
         logger.error(f"Error processing batch of {len(queries)} queries: {str(e)}")
         return [{
@@ -98,9 +109,25 @@ def process_query(entries, collection, embedding_generator, num_candidates):
     return batch_results
 
 
-@timeout_decorator.timeout(120, timeout_exception=TimeoutError)  # 120s timeout per query
-def evaluate_retrieval_performance(dataset, collection, embedding_generator, num_candidates=100):
-    """Evaluate retrieval performance with sequential queries and timing."""
+@timeout_decorator.timeout(1200, timeout_exception=TimeoutError)  # overall timeout
+def evaluate_retrieval_performance(
+    dataset,
+    collection,
+    embedding_generator,
+    num_candidates=100,
+    output_file=None,
+    max_retries=3,
+):
+    """Evaluate retrieval performance with sequential queries and timing.
+
+    Args:
+        dataset: Dataset of queries.
+        collection: MongoDB collection with the vector index.
+        embedding_generator: Embedding model wrapper.
+        num_candidates: Number of candidates per query.
+        output_file: Optional path to save incremental results in JSONL format.
+        max_retries: Retry attempts for each vector search.
+    """
     logger = logging.getLogger(__name__)
     
     total_queries = len(dataset)
@@ -122,16 +149,22 @@ def evaluate_retrieval_performance(dataset, collection, embedding_generator, num
     logger.info(f"Starting batch evaluation with {total_queries} queries, {num_candidates} candidates")
     #logger.debug(f"Evaluation parameters: k={k}, batch_size={BATCH_SIZE}")
     start_total_time = time.time()
-    
+
     start_overhead = time.time()
     results = []
+    out_f = open(output_file, "a") if output_file else None
     try:
         for i in tqdm(range(0, len(dataset), BATCH_SIZE), desc="Processing query batches", disable=not VERBOSE):
             batch = dataset[i:i + BATCH_SIZE]
             # logger.debug(f"Processing batch {i//BATCH_SIZE + 1} with {len(batch)} queries")
             try:
-                batch_results = process_query(batch, collection, embedding_generator, num_candidates)
+                batch_results = process_query(
+                    batch, collection, embedding_generator, num_candidates, max_retries
+                )
                 results.extend(batch_results)
+                if out_f:
+                    for br in batch_results:
+                        out_f.write(json.dumps(br) + "\n")
                 if (i // BATCH_SIZE + 1) % 10 == 0:
                     logger.info(f"Processed {i + len(batch)}/{total_queries} queries")
             except TimeoutError:
@@ -146,6 +179,18 @@ def evaluate_retrieval_performance(dataset, collection, embedding_generator, num
                         "has_results": False,
                         "timings": {"query_preprocessing": 0, "query_encoding": 0, "vector_search": 0}
                     })
+                if out_f:
+                    for entry in batch:
+                        out_f.write(json.dumps({
+                            "latency": 0,
+                            "results": [],
+                            "retrieved_docs": [],
+                            "relevant_count": 0,
+                            "possible_relevant": 0,
+                            "query": entry["input"],
+                            "has_results": False,
+                            "timings": {"query_preprocessing": 0, "query_encoding": 0, "vector_search": 0}
+                        }) + "\n")
             except Exception as e:
                 logger.error(f"Error in batch {i//BATCH_SIZE + 1}: {str(e)}")
                 continue
@@ -184,6 +229,9 @@ def evaluate_retrieval_performance(dataset, collection, embedding_generator, num
         key: (query_timings[key] / total_time) if total_time > 0 else 0
         for key in query_timings
     }
+
+    if out_f:
+        out_f.close()
 
     client = MongoClient(DB_URI)
     db = client[DB_NAME]

--- a/generate_hotpotqa_subset.py
+++ b/generate_hotpotqa_subset.py
@@ -1,0 +1,49 @@
+import json
+import argparse
+from datasets import load_dataset
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a KILT corpus subset containing documents referenced by HotpotQA queries.")
+    parser.add_argument("--dataset", default="facebook/kilt_tasks", help="Dataset with HotpotQA tasks")
+    parser.add_argument("--subset", default="hotpotqa", help="Subset name (default: hotpotqa)")
+    parser.add_argument("--corpus", default="corag/kilt-corpus", help="KILT corpus dataset name")
+    parser.add_argument("--output", default="hotpotqa_corpus_subset.jsonl", help="Output JSONL file")
+    parser.add_argument("--split", default="train", help="Split to use for HotpotQA queries (default: train)")
+    args = parser.parse_args()
+
+    print(f"Loading HotpotQA dataset: {args.dataset} ({args.subset})")
+    hotpotqa = load_dataset(args.dataset, name=args.subset, split=args.split)
+
+    wiki_ids = set()
+    titles = set()
+    for entry in hotpotqa:
+        for output in entry.get("output", []):
+            for prov in output.get("provenance", []):
+                wid = prov.get("wikipedia_id")
+                title = prov.get("title")
+                if wid:
+                    wiki_ids.add(str(wid))
+                if title:
+                    titles.add(title.strip())
+
+    print(f"Found {len(wiki_ids)} unique wikipedia_ids and {len(titles)} titles in provenance")
+
+    print(f"Streaming KILT corpus {args.corpus} to gather matching documents...")
+    corpus = load_dataset(args.corpus, split="train", streaming=True)
+    matched = 0
+    with open(args.output, "w") as f:
+        for doc in corpus:
+            if str(doc.get("wikipedia_id")) in wiki_ids or doc.get("title", "").strip() in titles:
+                matched += 1
+                record = {
+                    "wikipedia_id": doc["wikipedia_id"],
+                    "wikipedia_title": doc["title"],
+                    "contents": doc["contents"],
+                }
+                f.write(json.dumps(record) + "\n")
+    print(f"Saved {matched} documents to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,15 +1,20 @@
 import logging
+import os
 import torch
 from transformers.utils import logging as transformers_logging
 from sentence_transformers import SentenceTransformer
 from data_loader import load_and_store_data
 from evaluation import evaluate_retrieval_performance
 from embedding_utils import EmbeddingGenerator
-from config import MODEL_CONFIGS, VERBOSE, limit, K, numCandidates
+from config import MODEL_CONFIGS, VERBOSE, limit, K, numCandidates as DEFAULT_NUM_CANDIDATES
 from system_evaluation import SystemEvaluator
+import gc
 
-def run_study(model_name, embedding_size):
+def run_study(model_name, embedding_size, num_candidates=DEFAULT_NUM_CANDIDATES, output_file=None):
     logger = logging.getLogger(__name__)
+    if output_file is None:
+        safe_name = model_name.replace("/", "_")
+        output_file = os.getenv("OUTPUT_FILE", f"results_{safe_name}.jsonl")
     if torch.cuda.is_available():
         logger.info(f"Running on GPU: {torch.cuda.get_device_name(0)} ({torch.cuda.device_count()} device(s))")
     else:
@@ -18,38 +23,57 @@ def run_study(model_name, embedding_size):
     
     evaluator = SystemEvaluator()
     results = {}
+    collection = None
+    dataset_raw = None
+    dataset = None
     logger.info("Running batch embedding mode")
     embedding_generator = EmbeddingGenerator(model_name, embedding_size, quantize=False)
-    
-    evaluator.start_monitoring()
-    collection, dataset_raw, data_timings, data_stats = load_and_store_data(
-        limit=limit, embedding_generator=embedding_generator, embedding_size=embedding_size
-    )
-    data_duration, data_cpu_delta = evaluator.end_monitoring("Data Load (batch)")
 
-    # Ensure dataset is a list of dictionaries
-    dataset = [dict(item) for item in dataset_raw]
+    try:
+        evaluator.start_monitoring()
+        collection, dataset_raw, data_timings, data_stats = load_and_store_data(
+            limit=limit, embedding_generator=embedding_generator, embedding_size=embedding_size
+        )
+        data_duration, data_cpu_delta = evaluator.end_monitoring("Data Load (batch)")
 
-    logger.info(f"\nRunning evaluation (top-{K}, numCandidates={numCandidates}, batch)...")
-    evaluator.start_monitoring()
-    metrics_k = evaluate_retrieval_performance(
-        dataset, collection, embedding_generator, num_candidates=numCandidates
-    )
-    eval_duration_k, eval_cpu_delta_k = evaluator.end_monitoring(f"Evaluation (top-{K}, batch)")
-    
-    if metrics_k["avg_precision"] == 0:
-        logger.warning(f"Zero precision detected for {model_name} (batch). Check embedding dimensions and vector index.")
-    
-    results["batch"] = {
-        "data_timings": data_timings,
-        "data_stats": data_stats,
-        "metrics_k": metrics_k,
-        "eval_duration_k": eval_duration_k
-    }
-    
+        # Ensure dataset is a list of dictionaries
+        dataset = [dict(item) for item in dataset_raw]
+
+        logger.info(f"\nRunning evaluation (top-{K}, numCandidates={num_candidates}, batch)...")
+        evaluator.start_monitoring()
+        metrics_k = evaluate_retrieval_performance(
+            dataset,
+            collection,
+            embedding_generator,
+            num_candidates=num_candidates,
+            output_file=output_file,
+        )
+        eval_duration_k, eval_cpu_delta_k = evaluator.end_monitoring(f"Evaluation (top-{K}, batch)")
+
+        if metrics_k["avg_precision"] == 0:
+            logger.warning(f"Zero precision detected for {model_name} (batch). Check embedding dimensions and vector index.")
+
+        results["batch"] = {
+            "data_timings": data_timings,
+            "data_stats": data_stats,
+            "metrics_k": metrics_k,
+            "eval_duration_k": eval_duration_k
+        }
+    finally:
+        logger.info("Cleaning up resources...")
+        try:
+            if collection is not None:
+                collection.database.client.close()
+        except Exception as e:
+            logger.warning(f"Failed to close Mongo client: {e}")
+        # Explicitly delete large objects
+        del dataset_raw, dataset, embedding_generator
+        torch.cuda.empty_cache()
+        gc.collect()
+
     return results
 
-def summarize_results(model_name, results):
+def summarize_results(model_name, results, num_candidates):
     logger = logging.getLogger(__name__)
     config = MODEL_CONFIGS[model_name]
     embedding_size = config["embedding_size"]
@@ -81,6 +105,7 @@ def summarize_results(model_name, results):
     else:
         logger.info(f"  Parameters: {parameters}")
     logger.info(f"  Embedding Size: {embedding_size}")
+    logger.info(f"  Num Candidates: {num_candidates}")
     
     logger.info(f"\nDataset and Database Statistics:")
     logger.info(f"{'Metric':<40} {'Value':<20}")
@@ -140,17 +165,29 @@ def main():
     logger = logging.getLogger(__name__)
     logger.info("Starting RAG retrieval evaluation...")
     logger.debug(f"Configured models: {list(MODEL_CONFIGS.keys())}")
-    models = [
-        "sentence-transformers/all-MiniLM-L6-v2",
-        "BAAI/bge-base-en-v1.5",
-        "thenlper/gte-base"
-    ]
 
-    for model_name in models:
+    models_env = os.getenv("MODELS")
+    if models_env:
+        models = [m.strip() for m in models_env.split(",") if m.strip()]
+    else:
+        models = [
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "BAAI/bge-base-en-v1.5",
+            "thenlper/gte-base",
+        ]
+
+    for idx, model_name in enumerate(models):
         embedding_size = MODEL_CONFIGS[model_name]["embedding_size"]
         logger.debug(f"Running study for model: {model_name}, embedding_size: {embedding_size}")
-        results = run_study(model_name, embedding_size)
-        summarize_results(model_name, results)
+
+        if idx == 0:
+            for num_cand in [30, 60]:
+                logger.info(f"Running {model_name} with numCandidates={num_cand}")
+                results = run_study(model_name, embedding_size, num_candidates=num_cand)
+                summarize_results(model_name, results, num_cand)
+        else:
+            results = run_study(model_name, embedding_size, num_candidates=30)
+            summarize_results(model_name, results, 30)
 
 if __name__ == "__main__":
     main()

--- a/retrieval.py
+++ b/retrieval.py
@@ -6,8 +6,15 @@ from config import BATCH_SIZE
 
 logger = logging.getLogger(__name__)
 
-def retrieve_top_k(query_embeddings, collection, num_candidates):
-    """Retrieve top-K documents from MongoDB using vector search for a batch of query embeddings."""
+def retrieve_top_k(query_embeddings, collection, num_candidates, retries=3):
+    """Retrieve top-K documents from MongoDB using vector search for a batch of query embeddings.
+
+    Args:
+        query_embeddings: List of query vectors.
+        collection: MongoDB collection with the vector index.
+        num_candidates: Number of candidate documents to retrieve.
+        retries: Number of times to retry a failed search.
+    """
     logger.info(f"Starting retrieval with num_candidates={num_candidates} for {len(query_embeddings)} queries.")
     logger.debug(f"Retrieval input: query_embeddings type={type(query_embeddings)}, len={len(query_embeddings)}, sample dims={len(query_embeddings[0]) if query_embeddings and query_embeddings[0] else 0}")
     
@@ -64,27 +71,44 @@ def retrieve_top_k(query_embeddings, collection, num_candidates):
         batch_start = time.time()
         for j, query_embedding in enumerate(batch):
             query_idx = i + j + 1
-            logger.debug(f"Processing query {query_idx} with vector (first 5 dims): type={type(query_embedding)}, value={query_embedding[:5]}")
-            try:
-                search_results = list(collection.aggregate(pipeline(query_embedding)))
-                logger.debug(f"Query {query_idx} raw search results: type={type(search_results)}, len={len(search_results)}, first item={search_results[0] if search_results else 'No results'}")
-                
-                validated_results = []
-                if not search_results:
-                    logger.warning(f"Query {query_idx} returned no results.")
-                else:
-                    for res in search_results:
-                        if not isinstance(res, dict):
-                            logger.error(f"Query {query_idx} search result is not a dictionary: type={type(res)} - value={res}")
-                            continue
-                        if "wikipedia_id" not in res or "wikipedia_title" not in res:
-                            logger.error(f"Query {query_idx} missing required fields in search result: {res.keys()}")
-                            continue
-                        validated_results.append(res)
-                batch_results.append(validated_results)
-            except Exception as e:
-                logger.error(f"Vector search failed for query {query_idx}: {str(e)}")
+            logger.debug(
+                f"Processing query {query_idx} with vector (first 5 dims): type={type(query_embedding)}, value={query_embedding[:5]}"
+            )
+            search_results = None
+            for attempt in range(retries):
+                try:
+                    search_results = list(collection.aggregate(pipeline(query_embedding)))
+                    break
+                except Exception as e:
+                    logger.error(
+                        f"Vector search failed for query {query_idx} (attempt {attempt + 1}/{retries}): {str(e)}"
+                    )
+                    time.sleep(1)
+            if search_results is None:
                 batch_results.append([])
+                continue
+
+            logger.debug(
+                f"Query {query_idx} raw search results: type={type(search_results)}, len={len(search_results)}, first item={search_results[0] if search_results else 'No results'}"
+            )
+
+            validated_results = []
+            if not search_results:
+                logger.warning(f"Query {query_idx} returned no results.")
+            else:
+                for res in search_results:
+                    if not isinstance(res, dict):
+                        logger.error(
+                            f"Query {query_idx} search result is not a dictionary: type={type(res)} - value={res}"
+                        )
+                        continue
+                    if "wikipedia_id" not in res or "wikipedia_title" not in res:
+                        logger.error(
+                            f"Query {query_idx} missing required fields in search result: {res.keys()}"
+                        )
+                        continue
+                    validated_results.append(res)
+            batch_results.append(validated_results)
         batch_search_time = time.time() - batch_start
         total_search_time += batch_search_time
         logger.debug(f"Batch {i//BATCH_SIZE + 1} retrieved {len(batch_results)} queries in {batch_search_time:.4f}s")


### PR DESCRIPTION
## Summary
- allow multiple models to be selected via `MODELS` env variable
- store partial evaluation results and retry vector search on failures
- expose output file path through `OUTPUT_FILE`
- update README with instructions for running each model in its own VM and using the full corpus

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840bb1cdc54832c8d437ccd0c2e0456